### PR TITLE
Fix overriden `onBeforeCompile` context

### DIFF
--- a/src/objects/InstancedMesh2.ts
+++ b/src/objects/InstancedMesh2.ts
@@ -156,7 +156,7 @@ export class InstancedMesh2<
   protected patchMaterial(material: Material): void {
     if (material.isInstancedMeshPatched) throw new Error('Cannot reuse already patched material.');
 
-    const onBeforeCompile = material.onBeforeCompile;
+    const onBeforeCompile = material.onBeforeCompile.bind(material);
 
     material.onBeforeCompile = (shader: WebGLProgramParametersWithUniforms, renderer) => {
       if (onBeforeCompile) onBeforeCompile(shader, renderer);


### PR DESCRIPTION
Fixed exception thrown when material to patch used 'this' within onBeforeMaterial.