### PR TITLE
Fix instance visibility if `perObjectFrustumCulled` is false

### DIFF
--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,0 +1,20 @@
+import { Main, PerspectiveCameraAuto } from "@three.ez/main";
+import { DirectionalLight, MeshPhongMaterial, Scene, SphereGeometry } from "three";
+import { InstancedMesh2 } from "../src/index.js";
+
+const main = new Main();
+
+const spheres = new InstancedMesh2(main.renderer, 99 * 99, new SphereGeometry(0.4), new MeshPhongMaterial({ color: 'cyan' }));
+spheres.perObjectFrustumCulled = false;
+
+spheres.updateInstances((obj, index) => {
+    obj.position.x = index % 99 - 49;
+    obj.position.y = Math.trunc(index / 99) - 49;
+});
+
+spheres.on('click', (e) => spheres.setVisibilityAt(e.intersection.instanceId, false));
+
+const camera = new PerspectiveCameraAuto(70).translateZ(5);
+const dirLight = new DirectionalLight().translateZ(5);
+const scene = new Scene().add(spheres, dirLight);
+main.createView({ scene, camera, backgroundColor: 'white' });

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <script type="module" src="./examples/LOD.ts"></script>
+  <script type="module" src="./examples/test.ts"></script>
   <span class="info" id="count"></span>
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@three.ez/instanced-mesh",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@three.ez/instanced-mesh",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "bvh.js": "^0.0.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@three.ez/instanced-mesh",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Simplified and enhanced InstancedMesh with frustum culling, fast raycasting (using BVH), sorting, visibility management and more.",
   "author": "Andrea Gargaro <devgargaro@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR does not fix the scenario where `sortObjects` is true, which will be fixed later.

cc @tobiascornille

related to #4 