### PR TITLE
Optional renderer parameter

### DIFF
--- a/examples/sorting.ts
+++ b/examples/sorting.ts
@@ -53,7 +53,7 @@ const gui = new GUI();
 gui.add(instancedMesh, "maxCount").name('instances max count').disable();
 const spheresCount = gui.add(instancedMesh, 'count').name('instances rendered').disable();
 gui.add(config, "count", 0, instancedMesh.maxCount).name('instances count').onChange((v) => instancedMesh.instancesCount = v);
-gui.add(config, "animatedCount", 0, 30000).name('instances animated');
+gui.add(config, "animatedCount", 0, 10000).name('instances animated');
 gui.add(instancedMesh, "perObjectFrustumCulled");
 gui.add(instancedMesh, "sortObjects");
 gui.add(instancedMesh.material, "opacity", 0, 1).onChange((v) => {

--- a/src/objects/GLInstancedBufferAttribute.ts
+++ b/src/objects/GLInstancedBufferAttribute.ts
@@ -1,15 +1,31 @@
-import { GLBufferAttribute, TypedArray } from "three";
+import { GLBufferAttribute, TypedArray, WebGLRenderer } from "three";
 
 export class GLInstancedBufferAttribute extends GLBufferAttribute {
     public isInstancedBufferAttribute = true;
     public isGLInstancedBufferAttribute = true;
     public meshPerAttribute: number;
     public array: TypedArray;
+    /** @internal */ public _needsUpdate = false;
 
-    constructor(buffer: WebGLBuffer, type: GLenum, itemSize: number, elementSize: 1 | 2 | 4, count: number, array: TypedArray, meshPerAttribute = 1) {
-        super(buffer, type, itemSize, elementSize, count);
+    constructor(gl: WebGL2RenderingContext, type: GLenum, itemSize: number, elementSize: 1 | 2 | 4, array: TypedArray, meshPerAttribute = 1) {
+        const buffer = gl.createBuffer();
+        super(buffer, type, itemSize, elementSize, array.length / itemSize);
+
         this.meshPerAttribute = meshPerAttribute;
         this.array = array;
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, array, gl.DYNAMIC_DRAW);
+    }
+
+    public update(renderer: WebGLRenderer, count: number): void {
+        if (!this._needsUpdate) return;
+
+        const gl = renderer.getContext();
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.array, 0, count);
+
+        this._needsUpdate = false;
     }
 
     public copy(source: GLInstancedBufferAttribute): this {


### PR DESCRIPTION
The renderer in the constructor is needed in order to create an `GLBufferAttribute` which is needed because `BufferAttribute` cannot be updated in the `onBeforerRender` callback (changes are seen in the next frame).

The renderer in the constructor is now optional. In case it is not specified, a temporary `BufferAttribute` is created, which is replaced when the renderer is accessed with the `onAfterRender` callback.

**⚠️ In case the renderer is not specified in the constructor, the first render will not be executed. ⚠️**