### PR TITLE
InstancedEntity: useEuler flag

### DIFF
--- a/examples/sorting.ts
+++ b/examples/sorting.ts
@@ -16,11 +16,11 @@ const geometry = await Asset.load<BufferGeometry>(BufferGeometryLoader, modelPat
 geometry.computeVertexNormals();
 
 const main = new Main();
-const camera = new PerspectiveCameraAuto(70).translateZ(100);
+const camera = new PerspectiveCameraAuto().translateZ(100);
 const scene = new Scene();
 
 const material = new MeshNormalMaterial();
-const instancedMesh = new InstancedMesh2(main.renderer, config.count, geometry, material);
+const instancedMesh = new InstancedMesh2(main.renderer, config.count, geometry, material, undefined, true);
 
 instancedMesh.createInstances((object) => {
   object.position.random().multiplyScalar(100).subScalar(50);
@@ -43,6 +43,7 @@ scene.on('animate', e => {
   for (let i = 0; i < config.animatedCount; i++) {
     const mesh = instancedMesh.instances[i];
     mesh.rotateOnAxis(axis, e.delta);
+    // mesh.rotation.x += e.delta;
     mesh.updateMatrix();
   }
 });

--- a/examples/tween.ts
+++ b/examples/tween.ts
@@ -8,7 +8,7 @@ const camera = new PerspectiveCameraAuto().translateZ(2);
 
 const planes = new InstancedMesh2(main.renderer, 20, new PlaneGeometry(), new MeshBasicMaterial(), undefined, true);
 
-const tempColor = new Color();
+// const tempColor = new Color();
 
 planes.createInstances((obj, index) => {
   obj.scale.multiplyScalar(1 - index * 0.05);

--- a/examples/tween.ts
+++ b/examples/tween.ts
@@ -1,0 +1,35 @@
+import { Main, PerspectiveCameraAuto, Tween } from '@three.ez/main';
+import { Color, Euler, MeshBasicMaterial, PlaneGeometry, Scene, Vector3 } from 'three';
+import { InstancedMesh2 } from '../src/index.js';
+
+const main = new Main();
+const scene = new Scene();
+const camera = new PerspectiveCameraAuto().translateZ(2);
+
+const planes = new InstancedMesh2(main.renderer, 20, new PlaneGeometry(), new MeshBasicMaterial(), undefined, true);
+
+const tempColor = new Color();
+
+planes.createInstances((obj, index) => {
+  obj.scale.multiplyScalar(1 - index * 0.05);
+  obj.color = index % 2 === 0 ? 'red' : 'cyan';
+
+  const rotation = new Euler(0, 0, (Math.PI / 2) * index);
+  const position = new Vector3(0, 0, 0.1 * index);
+  const color = new Color(0);
+
+  new Tween(obj)
+    .to(5000, { rotation, position, color }, {
+      onUpdate: () => obj.updateMatrix(),
+      // onProgress: (t, k, s, e, a) => {
+      //   if (k === 'color') obj.color = tempColor.lerpColors(s as Color, e as Color, a)
+      // }
+    })
+    .yoyoForever()
+    .start();
+});
+
+scene.add(planes);
+main.createView({ scene, camera, enabled: false });
+
+// TODO: FIX COLOR AND TWEEN TIME 0

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <script type="module" src="./examples/sorting.ts"></script>
+  <script type="module" src="./examples/tween.ts"></script>
   <span class="info" id="count"></span>
 </body>
 

--- a/src/objects/InstancedMesh2.ts
+++ b/src/objects/InstancedMesh2.ts
@@ -211,7 +211,7 @@ export class InstancedMesh2<
       instance.position.set(0, 0, 0);
       instance.scale.set(1, 1, 1);
       instance.quaternion.set(0, 0, 0, 1);
-      instance?.rotation.set(0, 0, 0, undefined);
+      instance.rotation?.set(0, 0, 0);
 
       onUpdate(instance as Entity<TCustomData>, i);
       instance.updateMatrix();


### PR DESCRIPTION
Previously `InstancedEntity` handled rotations only with quaternions. 
With the `instancesUseEuler` flag, the property `rotation` (`Euler`) is added. 
`rotation` and `quaternion` will always be synchronized like Object3D (might impact performance if you update many objects).