### PR TITLE
Fix scene override material

### DIFF
--- a/src/core/InstancedMesh2.ts
+++ b/src/core/InstancedMesh2.ts
@@ -1,4 +1,4 @@
-import { AttachedBindMode, BindMode, Box3, BufferAttribute, BufferGeometry, Camera, Color, ColorManagement, ColorRepresentation, DataTexture, DetachedBindMode, InstancedBufferAttribute, Material, Matrix4, Mesh, MeshDepthMaterial, MeshDistanceMaterial, Object3D, Object3DEventMap, RGBADepthPacking, Scene, Skeleton, SkinnedMesh, Sphere, Vector3, WebGLRenderer } from 'three';
+import { AttachedBindMode, BindMode, Box3, BufferAttribute, BufferGeometry, Camera, Color, ColorManagement, ColorRepresentation, DataTexture, DetachedBindMode, InstancedBufferAttribute, Material, Matrix4, Mesh, Object3D, Object3DEventMap, Scene, Skeleton, SkinnedMesh, Sphere, Vector3, WebGLProgramParametersWithUniforms, WebGLRenderer } from 'three';
 import { CustomSortCallback, OnFrustumEnterCallback } from './feature/FrustumCulling.js';
 import { Entity } from './feature/Instances.js';
 import { LODInfo } from './feature/LOD.js';
@@ -163,20 +163,12 @@ export class InstancedMesh2<
   /** @internal */ _capacity: number;
   /** @internal */ _indexArrayNeedsUpdate = false;
   /** @internal */ _geometry: TGeometry;
-  /** @internal */ _material: TMaterial;
   /** @internal */ _parentLOD: InstancedMesh2;
   protected readonly _allowsEuler: boolean;
   protected readonly _tempInstance: InstancedEntity;
   protected _useOpacity = false;
-
-  /**
-   * @defaultValue `new MeshDepthMaterial({ depthPacking: RGBADepthPacking })`
-   */
-  public override customDepthMaterial = new MeshDepthMaterial({ depthPacking: RGBADepthPacking });
-  /**
-   * @defaultValue `new MeshDistanceMaterial()`
-   */
-  public override customDistanceMaterial = new MeshDistanceMaterial();
+  protected _customProgramCacheKeyBase: () => string = null;
+  protected _onBeforeCompileBase: (parameters: WebGLProgramParametersWithUniforms, renderer: WebGLRenderer) => void = null;
 
   // HACK TO MAKE IT WORK WITHOUT UPDATE CORE
   /** @internal */ isInstancedMesh = true; // must be set to use instancing rendering
@@ -231,16 +223,6 @@ export class InstancedMesh2<
   }
 
   /**
-   * An instance of `material` (or derived classes) or an array of materials, defining the object's appearance.
-   */
-  // @ts-expect-error it's defined as a property, but is overridden as an accessor.
-  public override get material(): TMaterial { return this._material; }
-  public override set material(value: TMaterial) {
-    this._material = value;
-    this.patchMaterials(value);
-  }
-
-  /**
    * Create an `InstancedMesh2` instance from an existing `Mesh`.
    * @param mesh The mesh to create an `InstanceMesh2` from.
    * @param params  Optional configuration parameters object. See `InstancedMesh2Params` for details.
@@ -289,13 +271,12 @@ export class InstancedMesh2<
     this.initIndexAttribute();
     this.initMatricesTexture();
 
-    this.patchMaterial(this.customDepthMaterial);
-    this.patchMaterial(this.customDistanceMaterial);
-
     if (createEntities) this.createEntities();
   }
 
   public override onBeforeShadow(renderer: WebGLRenderer, scene: Scene, camera: Camera, shadowCamera: Camera, geometry: BufferGeometry, depthMaterial: Material, group: any): void {
+    this.patchMaterial(depthMaterial);
+
     if (!this.instanceIndex || (group && !this.isFirstGroup(group.materialIndex))) return;
 
     this.matricesTexture.update(renderer);
@@ -310,12 +291,15 @@ export class InstancedMesh2<
   }
 
   public override onBeforeRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, geometry: BufferGeometry, material: Material, group: any): void {
+    this.patchMaterial(material);
+
     if (!this.instanceIndex) {
       this._renderer = renderer;
       return;
     }
 
-    if (group && !this.isFirstGroup(group.materialIndex)) return; // multi material
+    // if multi material we compute frustum culling once
+    if (group && !this.isFirstGroup(group.materialIndex)) return;
 
     this.matricesTexture.update(renderer);
     this.colorsTexture?.update(renderer);
@@ -330,6 +314,7 @@ export class InstancedMesh2<
 
   public override onAfterRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, geometry: BufferGeometry, material: Material, group: any): void {
     // TODO fix group d.ts
+    this.unpatchMaterial(material);
     if (this.instanceIndex || (group && !this.isLastGroup(group.materialIndex))) return;
     this.initIndexAttribute();
   }
@@ -401,38 +386,21 @@ export class InstancedMesh2<
     }
   }
 
-  protected patchMaterials(material: TMaterial): void {
-    if (!material) return;
-
-    if ((material as Material).isMaterial) {
-      this.patchMaterial(material as Material);
-      return;
-    }
-
-    for (const m of material as Material[]) {
-      this.patchMaterial(m);
-    }
-  }
-
   protected patchMaterial(material: Material): void {
-    if (material.ez_patchOwner === this) return;
+    this._customProgramCacheKeyBase = material.customProgramCacheKey.bind(material);
+    this._onBeforeCompileBase = material.onBeforeCompile.bind(material);
 
-    if (material.ez_patchOwner) {
-      if (this.isMaterialUsedByLOD(material)) return; // TODO add check if morph or skeletal
-
-      console.warn('The material has been cloned because it was already used.');
-      material = material.clone();
-    }
-
-    const onBeforeCompile = material.onBeforeCompile.bind(material);
+    material.customProgramCacheKey = () => {
+      return `ezInstancedMesh2_${this._customProgramCacheKeyBase()}`;
+    };
 
     material.onBeforeCompile = (shader, renderer) => {
-      if (onBeforeCompile) onBeforeCompile(shader, renderer);
+      if (this._onBeforeCompileBase) this._onBeforeCompileBase(shader, renderer);
 
-      if (!shader.instancing) return;
+      if (!shader.customProgramCacheKey.startsWith('ezInstancedMesh2_')) return;
 
       shader.instancing = false;
-      shader.instancingColor = false;
+      shader.instancingColor = false; // TODO check if necessary
       shader.uniforms.matricesTexture = { value: this.matricesTexture };
 
       if (!shader.defines) shader.defines = {};
@@ -477,16 +445,13 @@ export class InstancedMesh2<
         shader.uniforms.boneTexture = { value: this.boneTexture };
       }
     };
-
-    material.ez_patchOwner = this;
   }
 
-  protected isMaterialUsedByLOD(material: Material): boolean {
-    if (this._parentLOD) {
-      for (const obj of this._parentLOD.LODinfo.objects) {
-        if (obj.material === material) return true;
-      }
-    }
+  protected unpatchMaterial(material: Material): void {
+    material.onBeforeCompile = this._onBeforeCompileBase;
+    material.customProgramCacheKey = this._customProgramCacheKeyBase;
+    this._onBeforeCompileBase = null;
+    this._customProgramCacheKeyBase = null;
   }
 
   /**

--- a/src/core/InstancedMesh2.ts
+++ b/src/core/InstancedMesh2.ts
@@ -312,6 +312,10 @@ export class InstancedMesh2<
     }
   }
 
+  public override onAfterShadow(renderer: WebGLRenderer, scene: Scene, camera: Camera, shadowCamera: Camera, geometry: BufferGeometry, depthMaterial: Material, group: any): void {
+    this.unpatchMaterial(depthMaterial);
+  }
+
   public override onAfterRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, geometry: BufferGeometry, material: Material, group: any): void {
     // TODO fix group d.ts
     this.unpatchMaterial(material);

--- a/src/core/feature/FrustumCulling.ts
+++ b/src/core/feature/FrustumCulling.ts
@@ -105,7 +105,7 @@ InstancedMesh2.prototype.frustumCulling = function (camera: Camera) {
     const customSort = this.customSort;
 
     if (customSort === null) {
-      _renderList.array.sort(!(this._material as Material)?.transparent ? sortOpaque : sortTransparent);
+      _renderList.array.sort(!(this.material as Material)?.transparent ? sortOpaque : sortTransparent);
     } else {
       customSort(_renderList.array);
     }
@@ -238,7 +238,7 @@ InstancedMesh2.prototype.frustumCullingLOD = function (LODrenderList: LODRenderL
     let levelDistance = levels[1].distance;
 
     if (customSort === null) {
-      list.sort(!(levels[0].object._material as Material)?.transparent ? sortOpaque : sortTransparent); // TODO improve multimaterial handling
+      list.sort(!(levels[0].object.material as Material)?.transparent ? sortOpaque : sortTransparent); // TODO improve multimaterial handling
     } else {
       customSort(list);
     }

--- a/src/core/feature/Raycasting.ts
+++ b/src/core/feature/Raycasting.ts
@@ -17,11 +17,11 @@ const _invMatrixWorld = new Matrix4();
 const _sphere = new Sphere();
 
 InstancedMesh2.prototype.raycast = function (raycaster: Raycaster, result: Intersection[]): void {
-  if (this._parentLOD || this._material === undefined) return;
+  if (this._parentLOD || this.material === undefined) return;
 
   const raycastFrustum = this.raycastOnlyFrustum && this._perObjectFrustumCulled && !this.bvh;
   _mesh.geometry = this._geometry;
-  _mesh.material = this._material;
+  _mesh.material = this.material;
 
   const originalRay = raycaster.ray;
   const originalNear = raycaster.near;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { type InstancedMesh2 } from './core/InstancedMesh2.js';
-
 export * from './core/InstancedEntity.js';
 export * from './core/InstancedMesh2.js';
 export * from './core/InstancedMeshBVH.js';
@@ -25,10 +23,3 @@ export * from './shaders/chunks/instanced_skinning_pars_vertex.glsl.js';
 export * from './shaders/chunks/instanced_vertex.glsl.js';
 
 export * from './utils/SortingUtils.js';
-
-/** @internal */
-declare module 'three' {
-  export interface Material {
-    ez_patchOwner: InstancedMesh2;
-  }
-}

--- a/src/utils/SortingUtils.ts
+++ b/src/utils/SortingUtils.ts
@@ -19,7 +19,7 @@ export function createRadixSort(target: InstancedMesh2): typeof radixSort<Instan
   };
 
   return function sortFunction(list: InstancedRenderItem[]): void {
-    options.reversed = !!(target._material as Material)?.transparent;
+    options.reversed = !!(target.material as Material)?.transparent;
 
     if (target._capacity > options.aux.length) {
       options.aux.length = target._capacity;


### PR DESCRIPTION
This PR fixes the use of `scene.overrideMaterial`, used by some post processing effects such as SSAO.

related #77 

