### PR TITLE
Fix opacity assignment 

### DIFF
--- a/src/core/InstancedMesh2.ts
+++ b/src/core/InstancedMesh2.ts
@@ -730,6 +730,7 @@ export class InstancedMesh2<
    * @returns The opacity of the instance.
    */
   public getOpacityAt(id: number): number {
+    if (!this._useOpacity) return 1;
     return this.colorsTexture._data[id * 4 + 3];
   }
 


### PR DESCRIPTION
Fix this syntax:

```ts
myInstancedMesh.instances[0].opacity -= 0.01;
```

if opacity is not set yet.