### PR TITLE
`createFrom`: add `InstancedMesh` support

### DIFF
--- a/src/core/InstancedEntity.ts
+++ b/src/core/InstancedEntity.ts
@@ -101,6 +101,39 @@ export class InstancedEntity {
   }
 
   /**
+   * Set the transformation matrix to identity matrix.
+   */
+  public setMatrixIdentity(): void {
+    const owner = this.owner;
+    const te = owner.matricesTexture._data;
+    const id = this.id;
+    const offset = id * 16;
+
+    te[offset + 0] = 1;
+    te[offset + 1] = 0;
+    te[offset + 2] = 0;
+    te[offset + 3] = 0;
+
+    te[offset + 4] = 0;
+    te[offset + 5] = 1;
+    te[offset + 6] = 0;
+    te[offset + 7] = 0;
+
+    te[offset + 8] = 0;
+    te[offset + 9] = 0;
+    te[offset + 10] = 1;
+    te[offset + 11] = 0;
+
+    te[offset + 12] = 0;
+    te[offset + 13] = 0;
+    te[offset + 14] = 0;
+    te[offset + 15] = 1;
+
+    owner.matricesTexture.enqueueUpdate(id);
+    owner.bvh?.move(id);
+  }
+
+  /**
    * Updates the transformation matrix with its current position, quaternion, and scale.
    * The updated matrix is stored in the `owner.matricesTexture`.
    */

--- a/src/core/InstancedMesh2.ts
+++ b/src/core/InstancedMesh2.ts
@@ -1,4 +1,4 @@
-import { AttachedBindMode, BindMode, Box3, BufferAttribute, BufferGeometry, Camera, Color, ColorManagement, ColorRepresentation, DataTexture, DetachedBindMode, InstancedBufferAttribute, Material, Matrix4, Mesh, Object3D, Object3DEventMap, Scene, Skeleton, SkinnedMesh, Sphere, TypedArray, Vector3, WebGLProgramParametersWithUniforms, WebGLRenderer } from 'three';
+import { AttachedBindMode, BindMode, Box3, BufferAttribute, BufferGeometry, Camera, Color, ColorManagement, ColorRepresentation, DataTexture, DetachedBindMode, InstancedBufferAttribute, InstancedMesh, Material, Matrix4, Mesh, Object3D, Object3DEventMap, Scene, Skeleton, SkinnedMesh, Sphere, TypedArray, Vector3, WebGLProgramParametersWithUniforms, WebGLRenderer } from 'three';
 import { CustomSortCallback, OnFrustumEnterCallback } from './feature/FrustumCulling.js';
 import { Entity } from './feature/Instances.js';
 import { LODInfo } from './feature/LOD.js';
@@ -235,10 +235,25 @@ export class InstancedMesh2<
    * @returns The created `InstancedMesh2` instance.
    */
   public static createFrom<TData = {}>(mesh: Mesh, params: InstancedMesh2Params = {}): InstancedMesh2<TData> {
+    if ((mesh as InstancedMesh).isInstancedMesh) {
+      params.capacity ??= (mesh as InstancedMesh).count;
+    }
+
     const instancedMesh = new InstancedMesh2<TData>(mesh.geometry, mesh.material, params);
 
     if ((mesh as SkinnedMesh).isSkinnedMesh) {
       instancedMesh.initSkeleton((mesh as SkinnedMesh).skeleton);
+    }
+
+    if ((mesh as InstancedMesh).isInstancedMesh) {
+      instancedMesh.addInstances((mesh as InstancedMesh).count);
+
+      for (let i = 0; i < (mesh as InstancedMesh).count; i++) {
+        (mesh as InstancedMesh).getMatrixAt(i, _tempMat4);
+        (mesh as InstancedMesh).getColorAt(i, _tempCol);
+        instancedMesh.setMatrixAt(i, _tempMat4);
+        instancedMesh.setColorAt(i, _tempCol);
+      }
     }
 
     // TODO add morph

--- a/src/core/feature/Instances.ts
+++ b/src/core/feature/Instances.ts
@@ -30,10 +30,10 @@ declare module '../InstancedMesh2.js' {
     /**
      * Adds new instances and optionally initializes them using a callback function.
      * @param count The number of new instances to add.
-     * @param onCreation A callback function to initialize each new entity.
+     * @param onCreation An optional callback to initialize each new entity.
      * @returns The current `InstancedMesh2` instance.
      */
-    addInstances(count: number, onCreation: UpdateEntityCallback<Entity<TData>>): this;
+    addInstances(count: number, onCreation?: UpdateEntityCallback<Entity<TData>>): this;
     /**
      * Removes instances by their ids.
      * @param ids The ids of the instances to remove.
@@ -49,7 +49,7 @@ declare module '../InstancedMesh2.js' {
     /** @internal */ clearTempInstancePosition(index: number): InstancedEntity;
     /** @internal */ clearInstance(instance: InstancedEntity): InstancedEntity;
     /** @internal */ createEntities(start: number): this;
-    /** @internal */ addInstance(id: number, onCreation: UpdateEntityCallback): void;
+    /** @internal */ addInstance(id: number, onCreation?: UpdateEntityCallback): void;
   }
 }
 
@@ -122,7 +122,7 @@ InstancedMesh2.prototype.createEntities = function (this: InstancedMesh2, start:
   return this;
 };
 
-InstancedMesh2.prototype.addInstances = function (count: number, onCreation: UpdateEntityCallback) {
+InstancedMesh2.prototype.addInstances = function (count: number, onCreation?: UpdateEntityCallback) {
   // refill holes created from removeInstances
   const freeIds = this._freeIds;
   if (freeIds.length > 0) {
@@ -152,12 +152,19 @@ InstancedMesh2.prototype.addInstances = function (count: number, onCreation: Upd
   return this;
 };
 
-InstancedMesh2.prototype.addInstance = function (id: number, onCreation: UpdateEntityCallback) {
+InstancedMesh2.prototype.addInstance = function (id: number, onCreation?: UpdateEntityCallback) {
   this._instancesCount++;
   this.setActiveAndVisibilityAt(id, true);
   const instance = this.instances ? this.clearInstance(this.instances[id]) : this.clearTempInstance(id);
-  onCreation(instance, id);
-  instance.updateMatrix();
+
+  if (onCreation) {
+    onCreation(instance, id);
+    instance.updateMatrix();
+  } else if (this.bvh) {
+    instance.setMatrixIdentity();
+    console.warn('InstancedMesh2.addInstances: if `computeBVH()` has already been called, it is better to valorize the instances in the `onCreation` callback for better performance.');
+  }
+
   this.bvh?.insert(id);
 };
 


### PR DESCRIPTION
It's now possible to easily convert an `InstancedMesh` to `InstancedMesh2`.