### PR TITLE
Fix LOD sorting logic in linearCullingLOD function

### DIFF
--- a/src/core/feature/FrustumCulling.ts
+++ b/src/core/feature/FrustumCulling.ts
@@ -342,10 +342,10 @@ InstancedMesh2.prototype.linearCullingLOD = function (LODrenderList: LODRenderLi
 
     if (_frustum.intersectsSphere(_sphere)) {
       if (sortObjects) {
-        if (!onFrustumEnter || onFrustumEnter(i, camera, cameraLOD)) continue;
-
-        const distance = _sphere.center.distanceToSquared(_cameraLODPos);
-        _renderList.push(distance, i);
+        if (!onFrustumEnter || onFrustumEnter(i, camera, cameraLOD)) {
+          const distance = _sphere.center.distanceToSquared(_cameraLODPos);
+          _renderList.push(distance, i);
+        }
       } else {
         const distance = _sphere.center.distanceToSquared(_cameraLODPos);
         const levelIndex = this.getObjectLODIndexForDistance(levels, distance);


### PR DESCRIPTION
When `sortObjects` was true, user added LODs, a bvh was not built, the frustum culling was failing