### PR TITLE
fix: vec4 vColor compatibility for three.js r183+

### DIFF
--- a/src/core/InstancedMesh2.ts
+++ b/src/core/InstancedMesh2.ts
@@ -457,11 +457,7 @@ export class InstancedMesh2<
         shader.defines['USE_VERTEX_COLOR'] = '';
       }
 
-      if (this._useOpacity) {
-        shader.defines['USE_COLOR_ALPHA'] = '';
-      } else {
-        shader.defines['USE_COLOR'] = '';
-      }
+      shader.defines['USE_COLOR_ALPHA'] = '';
     }
 
     if (this.boneTexture) {

--- a/src/shaders/chunks/instanced_color_pars_vertex.glsl
+++ b/src/shaders/chunks/instanced_color_pars_vertex.glsl
@@ -1,21 +1,11 @@
 #ifdef USE_INSTANCING_COLOR_INDIRECT
   uniform highp sampler2D colorsTexture;
 
-  #ifdef USE_COLOR_ALPHA
-    vec4 getColorTexture() {
-      int size = textureSize( colorsTexture, 0 ).x;
-      int j = int( instanceIndex );
-      int x = j % size;
-      int y = j / size;
-      return texelFetch( colorsTexture, ivec2( x, y ), 0 );
-    }
-  #else
-    vec3 getColorTexture() {
-      int size = textureSize( colorsTexture, 0 ).x;
-      int j = int( instanceIndex );
-      int x = j % size;
-      int y = j / size;
-      return texelFetch( colorsTexture, ivec2( x, y ), 0 ).rgb;
-    }
-  #endif
+  vec4 getColorTexture() {
+    int size = textureSize( colorsTexture, 0 ).x;
+    int j = int( instanceIndex );
+    int x = j % size;
+    int y = j / size;
+    return texelFetch( colorsTexture, ivec2( x, y ), 0 );
+  }
 #endif

--- a/src/shaders/chunks/instanced_color_vertex.glsl
+++ b/src/shaders/chunks/instanced_color_vertex.glsl
@@ -1,11 +1,7 @@
 #ifdef USE_INSTANCING_COLOR_INDIRECT
   #ifdef USE_VERTEX_COLOR
-    vColor = color;
+    vColor = vec4(color, 1.0);
   #else
-    #ifdef USE_COLOR_ALPHA
-      vColor = vec4( 1.0 );
-    #else
-      vColor = vec3( 1.0 );
-    #endif
+    vColor = vec4( 1.0 );
   #endif
 #endif


### PR DESCRIPTION
## Summary

Closes #159

three.js r183 changed `vColor` from conditionally `vec3`/`vec4` to always `vec4` ([three.js PR #32509](https://github.com/mrdoob/three.js/pull/32509)). This causes GLSL shader compilation errors when using `@three.ez/instanced-mesh`:

```
ERROR: 0:506: '=' : dimension mismatch
ERROR: 0:506: 'assign' : cannot convert from 'const 3-component vector of float' to 'out highp 4-component vector of float'
```

### Changes

- **`instanced_color_vertex.glsl`**: Always assign `vec4` to `vColor` (removes `USE_COLOR_ALPHA` conditional)
- **`instanced_color_pars_vertex.glsl`**: Always return `vec4` from `getColorTexture()` (removes vec3 branch)
- **`InstancedMesh2.ts`**: Always define `USE_COLOR_ALPHA` instead of conditionally setting `USE_COLOR` or `USE_COLOR_ALPHA`

### Backward compatibility

This remains compatible with three.js r182 and earlier because `USE_COLOR_ALPHA` ensures `vColor` is declared as `vec4` in older versions too. The `colorsTexture` is already created with 4 components (RGBA) and filled with `1.0`, so the alpha channel is safely `1.0` by default when opacity is not used.


### Repro
- Broken - https://jsfiddle.net/sdivelbiss/3urvnbhs/
- Fixed - https://jsfiddle.net/sdivelbiss/h3nbx01y/1/
- Backwards compatible with `three@0.182.0` - https://jsfiddle.net/sdivelbiss/epmj8v5t/ 

## Test plan

- [x] Verified build succeeds with `npm run build`
- [x] Verified no `vec3(1.0)` or bare `vColor = color` assignments in build output
- [x] Tested rendering with three.js r183 in a real application — seats render correctly on foundations