### PR TITLE
fix: restore WebGL pixel store parameters in SquareDataTexture.updateRows (#162)

### DIFF
--- a/src/core/utils/SquareDataTexture.ts
+++ b/src/core/utils/SquareDataTexture.ts
@@ -268,6 +268,11 @@ export class SquareDataTexture extends DataTexture {
     const texturePrimaries = this.colorSpace === NoColorSpace ? null : ColorManagement.getPrimaries(this.colorSpace);
     const unpackConversion = this.colorSpace === NoColorSpace || workingPrimaries === texturePrimaries ? gl.NONE : gl.BROWSER_DEFAULT_WEBGL;
 
+    const currentFlipY = gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL);
+    const currentPremultiplyAlpha = gl.getParameter(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL);
+    const currentAlignment = gl.getParameter(gl.UNPACK_ALIGNMENT);
+    const currentColorspaceConversion = gl.getParameter(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL);
+
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, this.flipY);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this.premultiplyAlpha);
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, this.unpackAlignment);
@@ -276,6 +281,11 @@ export class SquareDataTexture extends DataTexture {
     for (const { count, row } of info) {
       gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, row, width, count, glFormat, glType, data, row * width * channels);
     }
+
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, currentFlipY);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, currentPremultiplyAlpha);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, currentAlignment);
+    gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, currentColorspaceConversion);
 
     this.onUpdate?.(this);
   }


### PR DESCRIPTION
### Summary

Fixes #162 where `SquareDataTexture.updateRows()` corrupted global WebGL context pixel store state, causing subsequent canvas and image textures to upload vertically flipped.

### Root Cause

In `SquareDataTexture.ts`, `updateRows()` issues raw WebGL calls to mutate pixel store settings before calling `gl.texSubImage2D()`:

```ts
gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, this.flipY); // this.flipY is false for DataTexture
gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this.premultiplyAlpha);
gl.pixelStorei(gl.UNPACK_ALIGNMENT, this.unpackAlignment);
gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, unpackConversion);